### PR TITLE
IconCache: Simplify application of custom titles from STK

### DIFF
--- a/src/com/android/launcher3/IconCache.java
+++ b/src/com/android/launcher3/IconCache.java
@@ -597,12 +597,7 @@ public class IconCache {
                             if (DEBUG) Log.d(TAG, "using package default icon for " +
                                     componentName.toShortString());
                             entry.icon = packageEntry.icon;
-                            if (isCustomTitle) {
-                                entry.title = ((LauncherApplication) mContext)
-                                    .getStkAppName();
-                            } else {
-                                entry.title = packageEntry.title;
-                            }
+                            entry.title = packageEntry.title;
                             entry.contentDescription = packageEntry.contentDescription;
                         }
                     }
@@ -615,15 +610,16 @@ public class IconCache {
             }
 
             if (TextUtils.isEmpty(entry.title) && info != null) {
-                if (isCustomTitle) {
-                    entry.title = ((LauncherApplication) mContext)
-                        .getStkAppName();
-                } else {
-                    entry.title = info.getLabel();
-                }
+                entry.title = info.getLabel();
                 entry.contentDescription = mUserManager.getBadgedLabelForUser(entry.title, user);
             }
         }
+
+        if (isCustomTitle) {
+            entry.title = ((LauncherApplication) mContext)
+                .getStkAppName();
+        }
+
         return entry;
     }
 


### PR DESCRIPTION
Instead of trying to deal with multiple icon-cache conditions,
just apply the custom title to the entry right before using it.

This deals with hot-swap, card exchange, and similar weird issues
that were hitting stale cache entries, and is less aggressive
than outright flushing the cache with every STK refresh.

Issue: FEIJAO-815

Change-Id: Iacd7da820f0404b4dc12394d9c9a571bdceadeb0